### PR TITLE
Delete CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-devalmonte.com


### PR DESCRIPTION
This repo was previously pointing to `devalmonte.com`, a domain that I don't own anymore. Removing the `CNAME` file should make the page available at `maxalmonte14.github.io`